### PR TITLE
Add config flag to enable or disable Dialcode processing

### DIFF
--- a/post-publish-processor/src/main/resources/post-publish-processor.conf
+++ b/post-publish-processor/src/main/resources/post-publish-processor.conf
@@ -42,6 +42,7 @@ service {
 
 dialcode {
   linkable.primaryCategory = ["Course"]
+  enabled = false
 }
 
 activity {

--- a/post-publish-processor/src/main/scala/org/sunbird/job/postpublish/functions/PostPublishEventRouter.scala
+++ b/post-publish-processor/src/main/scala/org/sunbird/job/postpublish/functions/PostPublishEventRouter.scala
@@ -55,16 +55,21 @@ class PostPublishEventRouter(config: PostPublishProcessorConfig, httpUtil: HttpU
           context.output(config.activityBatchCreateOutTag, activityBatchDetails)
       }
 
-      // Process Dialcode link
-      val dialCodeDetails = getDialCodeDetails(identifier, event)(neo4JUtil, config)
-      if (!dialCodeDetails.isEmpty)
-        context.output(config.linkDIALCodeOutTag, dialCodeDetails)
+      // Process Dialcode link (only if enabled)
+      if (config.dialCodeEnabled) {
+        val dialCodeDetails = getDialCodeDetails(identifier, event)(neo4JUtil, config)
+        if (!dialCodeDetails.isEmpty)
+          context.output(config.linkDIALCodeOutTag, dialCodeDetails)
+      }
 
-      val dialcodeContextMap = getDialCodeContextMap(event)
-      if(!dialcodeContextMap.isEmpty)
-        context.output(config.dialcodeContextOutTag, dialcodeContextMap)
+      // Process Dialcode context (only if enabled)
+      if (config.dialCodeEnabled) {
+        val dialcodeContextMap = getDialCodeContextMap(event)
+        if(!dialcodeContextMap.isEmpty)
+          context.output(config.dialcodeContextOutTag, dialcodeContextMap)
+      }
     }
-    else if (event.action.equals("post-publish-process") && event.eData.contains("addContextDialCodes") && event.eData.contains("removeContextDialCodes")) {
+    else if (config.dialCodeEnabled && event.action.equals("post-publish-process") && event.eData.contains("addContextDialCodes") && event.eData.contains("removeContextDialCodes")) {
       val dialcodeContextMap = getDialCodeContextMap(event)
       if(!dialcodeContextMap.isEmpty)
         context.output(config.dialcodeContextOutTag, dialcodeContextMap)

--- a/post-publish-processor/src/main/scala/org/sunbird/job/postpublish/task/PostPublishProcessorConfig.scala
+++ b/post-publish-processor/src/main/scala/org/sunbird/job/postpublish/task/PostPublishProcessorConfig.scala
@@ -97,6 +97,9 @@ class PostPublishProcessorConfig(override val config: Config) extends BaseJobCon
   // Activity Batch Creation Configuration
   val activityBatchCreationEnabled: Boolean = if (config.hasPath("activity.batch.creation.enabled")) config.getBoolean("activity.batch.creation.enabled") else false
 
+  // Dial Code Configuration
+  val dialCodeEnabled: Boolean = if (config.hasPath("dialcode.enabled")) config.getBoolean("dialcode.enabled") else false
+
   // Timezone Configuration
   val timezone: String = if (config.hasPath("job.timezone")) config.getString("job.timezone") else "Asia/Kolkata"
 


### PR DESCRIPTION
Introduced a 'dialcode.enabled' configuration property to control whether Dialcode-related processing is performed in the post-publish processor. Updated the event router logic to check this flag before executing Dialcode link and context operations, allowing for easier toggling of this feature.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules